### PR TITLE
Speed up the IP to vlan search and add multiple vlan ids for hosts with multiple IPs

### DIFF
--- a/common/LDIFutils.py
+++ b/common/LDIFutils.py
@@ -25,6 +25,9 @@ def entry_string(entry):
         if isinstance(value, (list, tuple)):
             for val in value:
                 result += handle_value(val)
+        elif isinstance(value, set):
+            for val in sorted(value):
+                result += handle_value(val)
         elif isinstance(value, (int, str)):
             result += handle_value(value)
         else:

--- a/common/utils.py
+++ b/common/utils.py
@@ -101,14 +101,8 @@ def compare_file_size(oldfile, newfile, newlines):
     with open(oldfile, 'r', encoding=encoding) as old:
         oldlines = old.readlines()
 
-    if len(oldlines)==len(newlines):
-        different = False
-        for i in range(0, len(oldlines)):
-            if oldlines[i] != newlines[i]:
-                different = True
-                break
-        if not different:
-            return
+    if newlines == oldlines:
+        return
 
     old_count = len(oldlines)
     diff_limit = cfg['default'].getfloat('max_line_change_percent')

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -68,7 +68,7 @@ def create_ip_to_vlan_mapping(hosts, networks):
             else:
                 while lowest_network.broadcast_address < ip:
                     if not networks:
-                        logger.info(f"IP after last network: {ip}")
+                        logger.debug(f"IP after last network: {ip}")
                         break
                     lowest_network = networks.pop(0)
                     vlan = net_to_vlan[lowest_network]

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -161,7 +161,7 @@ def create_ldif(ldifdata, ignore_size_change):
             entry['uioHostMacAddr'] = sorted(mac)
         for ipaddr in i['ips']:
             if ipaddr in ip2vlan:
-                if not 'uioVlanID' in entry:
+                if 'uioVlanID' not in entry:
                     entry['uioVlanID'] = set()
                 entry['uioVlanID'].add(ip2vlan[ipaddr])
         _write(entry)
@@ -221,7 +221,7 @@ def main():
             error(f"Missing section {i} in config file", os.EX_CONFIG)
 
     if 'filename' not in cfg['default']:
-        error(f"Missing 'filename' in default section in config file", os.EX_CONFIG)
+        error("Missing 'filename' in default section in config file", os.EX_CONFIG)
 
     common.utils.cfg = cfg
     logger = common.utils.getLogger()


### PR DESCRIPTION
A mix of things which started out when speeding up the IP to vlan matching:
- Fixed a bug with not ignoring networks without vlan leading to some hosts with multiple IPs not getting any vlan id
- Add vlan IDs for IPs from PTR overrides. Hosts with names not controlled by mreg.
- The probably biggest one: instead of picking the vlan of a random / lowest IP, add entries for all IPs which have a vlan
