### PR TITLE
Add network policy LDAP attributes

### DIFF
--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -166,14 +166,11 @@ def create_ldif(ldifdata, ignore_size_change):
                 entry['uioVlanID'].add(ip2vlan[ipaddr])
 
         # Add the host's community
-        communities = i["communities"]
-        if communities:
+        if communities := i["communities"]:
             # NOTE: use only first community per host (FOR NOW!)
             com = communities[0]["community"]
             com_name = com["global_name"] or com["name"]
-        else:
-            com_name = "default"
-        entry["uioHostNetworkPolicy"] = com_name
+            entry["uioHostNetworkPolicy"] = com_name
 
         _write(entry)
         for cinfo in i["cnames"]:

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -370,14 +370,14 @@ def create_ldif(ldifdata, ignore_size_change):
                             ", ".join(com.community for com in communities),
                         )
                         break
+                else:
+                    logger.warning("Unable to determine isolated policy for host %s with multiple communities", i["name"])
+            # Host is part of a single community
             elif len(communities) == 1:
-                # Host is part of a community. Add the first community found
-                # NOTE: use only first community per host (FOR NOW!)
-                # TODO: log if multiple communities per host?
                 com = communities.pop()
                 host_net_policy = com.community_global or com.community
+            # Host is not part of a community, and its policy includes the isolated attribute
             elif pol := policies.get_isolated_policy():
-                # Host is not part of a community, and its policy includes the isolated attribute
                 host_net_policy = pol.policy.get_isolated_name()
 
             if host_net_policy:

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -164,6 +164,17 @@ def create_ldif(ldifdata, ignore_size_change):
                 if 'uioVlanID' not in entry:
                     entry['uioVlanID'] = set()
                 entry['uioVlanID'].add(ip2vlan[ipaddr])
+
+        # Add the host's community
+        communities = i["communities"]
+        if communities:
+            # NOTE: use only first community per host (FOR NOW!)
+            com = communities[0]["community"]
+            com_name = com["global_name"] or com["name"]
+        else:
+            com_name = "default"
+        entry["uioHostNetworkPolicy"] = com_name
+
         _write(entry)
         for cinfo in i["cnames"]:
             _write(_base_entry(cinfo["name"]))

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -202,7 +202,7 @@ class NetworkPolicy(NamedTuple):
 
     name: str
     description: str | None = None # NOTE: can we remove union type? TextField(blank=True, ...) in model
-    template_name: str | None = None
+    community_template_pattern: str | None = None
     attributes: tuple[str, ...] = tuple()
 
 class HostNetworkPolicy(NamedTuple):
@@ -257,7 +257,7 @@ def create_network_to_policy_mapping(
         net_to_policy[network] = NetworkPolicy(
             name=policy["name"],
             description=policy.get("description"),
-            template_name=policy.get("community_mapping_prefix") or policy.get("template_name"),
+            community_template_pattern=policy.get("community_mapping_prefix") or policy.get("community_template_pattern"),
             attributes=tuple(attributes),
         )
     return net_to_policy
@@ -348,7 +348,7 @@ def create_ldif(ldifdata, ignore_size_change):
                 host_net_policy = com.name
             elif pol := policies.get_isolated_policy():
                 # Host is not part of a community, and its policy includes the isolated attribute
-                host_net_policy = f"{pol.policy.template_name}_isolated"
+                host_net_policy = f"{pol.policy.community_template_pattern}_isolated"
 
             if host_net_policy:
                 entry["uioHostNetworkPolicy"] = host_net_policy

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -170,8 +170,8 @@ def get_host_communities(
         if not ip_obj:
             logger.debug(f"No IP address found for ID {ip_id} on host {host['name']}")
             continue
-        ip = ip_obj["ipaddress"]
         mac = ip_obj["macaddress"]
+        ip = ip_obj["ipaddress"]
 
         # Construct the HostCommunity object
         community = community_obj.get("community")

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -220,9 +220,6 @@ class HostPolicies:
     def __init__(self, policies: set[HostNetworkPolicy]):
         self.policies = policies
 
-    def __iter__(self) -> Iterator[HostNetworkPolicy]:
-        return iter(self.policies)
-
     def get_isolated_policy(self) -> HostNetworkPolicy | None:
         """Get the first isolated policy for the host, if any."""
         for policy in self.policies:

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -251,7 +251,7 @@ def create_network_to_policy_mapping(
         net_to_policy[network] = NetworkPolicy(
             name=policy["name"],
             description=policy.get("description"),
-            community_template_pattern=policy.get("community_mapping_prefix") or policy.get("community_template_pattern"),
+            community_template_pattern=policy.get("community_template_pattern") or policy.get("community_mapping_prefix"),
             attributes=tuple(attributes),
         )
     return net_to_policy

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -337,7 +337,7 @@ def create_ldif(ldifdata, ignore_size_change):
                     entry['uioVlanID'] = set()
                 entry['uioVlanID'].add(ip2vlan[ipaddr])
 
-        # Add the host's network policy (using the community's global name, else <policy>_isolated)
+        # Add the host's network policy (using the community's global name, else <template_pattern>_isolated)
         policies = get_host_policies(i, net2policy)
         if policies:
             host_net_policy: str | None = None

--- a/network-ldif/network-ldif.py
+++ b/network-ldif/network-ldif.py
@@ -45,8 +45,8 @@ def create_ldif(networks, ignore_size_change):
             }
         if i['vlan'] is not None:
             entry['uioVlanID'] = i['vlan']
-        if i['policy']:  # exists and not empty
-            entry['uioNetworkPolicy'] = i['policy']['name']
+        if i['policy'] and (pol_name := i['policy']['name']):
+            entry['uioNetworkPolicy'] = pol_name
         f.write(entry_string(entry))
     try:
         common.utils.write_file(cfg['default']['filename'], f,

--- a/network-ldif/network-ldif.py
+++ b/network-ldif/network-ldif.py
@@ -45,6 +45,8 @@ def create_ldif(networks, ignore_size_change):
             }
         if i['vlan'] is not None:
             entry['uioVlanID'] = i['vlan']
+        if i['policy']:  # exists and not empty
+            entry['uioNetworkPolicy'] = i['policy']['name']
         f.write(entry_string(entry))
     try:
         common.utils.write_file(cfg['default']['filename'], f,

--- a/network-ldif/network-ldif.py
+++ b/network-ldif/network-ldif.py
@@ -45,8 +45,6 @@ def create_ldif(networks, ignore_size_change):
             }
         if i['vlan'] is not None:
             entry['uioVlanID'] = i['vlan']
-        if i['policy'] and (pol_name := i['policy']['name']):
-            entry['uioNetworkPolicy'] = pol_name
         f.write(entry_string(entry))
     try:
         common.utils.write_file(cfg['default']['filename'], f,


### PR DESCRIPTION
This PR adds support for globally mapped community names from network policies through a new `uioHostNetworkPolicy` field.