### PR TITLE
Add hosts-ldif `--use-saved-data` option

### DIFF
--- a/common/connection.py
+++ b/common/connection.py
@@ -75,6 +75,7 @@ class Connection:
         headers = {'content-type': 'application/json'}
         url = requests.compat.urljoin(self.url, path)
         jsondata = json.dumps(data)
+        self.logger.info("%s %s", type.upper(), url)
         result = getattr(self._session, type)(url, data=jsondata, headers=headers)
 
         if first and result.status_code == 401:

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -53,6 +53,8 @@ class LdifData:
             with open(filename, 'wb') as f:
                 pickle.dump(objects, f)
         else:
+            if not os.path.isfile(filename):
+                error(f"No saved data file {filename} to use")
             with open(filename, 'rb') as f:
                 objects = pickle.load(f)
         return objects

--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -58,11 +58,11 @@ class LdifData:
         return objects
 
     @common.utils.timing
-    def get_entries(self, force=True):
+    def get_entries(self, force=True, use_saved_data=False):
         for name, endpoint in self.sources.items():
             url = self._url(endpoint)
             _updated = getattr(self, f"_updated_{name}") or force
-            objects = self._get_entries(url, name, update=_updated)
+            objects = self._get_entries(url, name, update=_updated and not use_saved_data)
             setattr(self, f"{name}", objects)
 
     @property
@@ -395,8 +395,8 @@ def hosts_ldif(args):
     if lock.acquire(blocking=False):
         ldifdata = LdifData(conn=conn, sources=SOURCES)
 
-        if ldifdata.updated or args.force_check:
-            ldifdata.get_entries(force=args.force_check)
+        if ldifdata.updated or args.force_check or args.use_saved_data:
+            ldifdata.get_entries(force=args.force_check, use_saved_data=args.use_saved_data)
             create_ldif(ldifdata, args.ignore_size_change)
             if 'postcommand' in cfg['default']:
                 common.utils.run_postcommand()
@@ -419,6 +419,9 @@ def main():
     parser.add_argument('--ignore-size-change',
                         action='store_true',
                         help='ignore size changes')
+    parser.add_argument('--use-saved-data',
+                        action='store_true',
+                        help='force use saved data from previous runs. --force-check')
     args = parser.parse_args()
 
     cfg = configparser.ConfigParser()


### PR DESCRIPTION
This PR adds a new `--use-saved-data` option for hosts-ldif.py, which causes the script to always used pickled data even if API signals that new data exists. Also adds a check which causes an error if the pickle file doesn't exist.