### PR TITLE
Use single VLAN ID in hosts-ldif

### DIFF
--- a/hosts-ldif/hosts-ldif.py
+++ b/hosts-ldif/hosts-ldif.py
@@ -338,9 +338,11 @@ def create_ldif(ldifdata, ignore_size_change):
             entry['uioHostMacAddr'] = sorted(mac)
         for ipaddr in i['ips']:
             if ipaddr in ip2vlan:
-                if 'uioVlanID' not in entry:
-                    entry['uioVlanID'] = set()
-                entry['uioVlanID'].add(ip2vlan[ipaddr])
+                entry['uioVlanID'] = ip2vlan[ipaddr]
+                if len(i["ips"]) > 1:
+                    logger.warning("Multiple IPs for host %s, using VLAN %s from IP %s",
+                                   i["name"], ip2vlan[ipaddr], ipaddr)
+                break
 
         # Add the host's network policy (using the community's global name, else <template_pattern>_isolated)
         policies = get_host_policies(i, net2policy)


### PR DESCRIPTION
This PR partially reverts #8. `uioVlanID` doesn't support multiple values. Until a solution can be found on that front, we have to select a single VLAN ID. We simply use the first VLAN ID and assume that stays consistent between runs (which we have reason to believe, as currently the VLAN IDs are sorted numerically).